### PR TITLE
Fix NV14 touch behavior.

### DIFF
--- a/radio/src/targets/nv14/touch_driver.cpp
+++ b/radio/src/targets/nv14/touch_driver.cpp
@@ -553,5 +553,7 @@ TouchState touchPanelRead()
   TouchState ret = internalTouchState;
   internalTouchState.deltaX = 0;
   internalTouchState.deltaY = 0;
+  if(internalTouchState.event == TE_UP)
+    internalTouchState.event = TE_NONE;
   return ret;
 }


### PR DESCRIPTION
TE_UP needs to be resettet to TE_NONE after touch read from MainWindow. If this is not done, the TE_UP event is handled multiple times

Please note that pull requests are NOT an appropriate way to ask questions or for support.

For feature request or bug reports, please use the Issues tab.
For support, please use the Discussion tab or join us on Discord.
<!-- Please delete the above if not relevant, and any of the below which does not apply -->

Fixes #

Summary of changes:
